### PR TITLE
Add missing `get_cache_key` to `_IndirectionMapRecorder`

### DIFF
--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -1279,6 +1279,10 @@ class FusionContractorArrayContext(
         indirection_maps = set()
 
         class _IndirectionMapRecorder(pt.transform.CachedWalkMapper):
+            # type-ignore-reason: dropped the extra `*args, **kwargs`.
+            def get_cache_key(self, expr) -> int:  # type: ignore[override]
+                return id(expr)
+
             def post_visit(self, expr):
                 if isinstance(expr, pt.IndexBase):
                     for idx in expr.indices:


### PR DESCRIPTION
@kaushikcfd Looks like the default implementation was removed? This appears to be causing some failures in mirgecom CI: https://github.com/illinois-ceesd/mirgecom/actions/runs/3466345190/jobs/5805722455